### PR TITLE
PropSkipFields

### DIFF
--- a/routeros/datasource_files.go
+++ b/routeros/datasource_files.go
@@ -53,7 +53,7 @@ func DatasourceFiles() *schema.Resource {
 							Computed: true,
 						},
 						"size": {
-							Type:     schema.TypeFloat,
+							Type:     schema.TypeInt,
 							Computed: true,
 						},
 						"type": {

--- a/routeros/datasource_interfaces.go
+++ b/routeros/datasource_interfaces.go
@@ -13,7 +13,11 @@ func DatasourceInterfaces() *schema.Resource {
 		Schema: map[string]*schema.Schema{
 			MetaResourcePath: PropResourcePath("/interface"),
 			MetaId:           PropId(Id),
-
+			MetaSkipFields: PropSkipFields(
+				"fp_rx_byte", "fp_rx_packet", "fp_tx_byte", "fp_tx_packet", "link_downs",
+				"rx_byte", "rx_drop", "rx_error", "rx_packet", "tx_byte",
+				"tx_drop", "tx_error", "tx_packet", "tx_queue_drop",
+			),
 			KeyFilter: PropFilterRw,
 			"interfaces": {
 				Type:     schema.TypeList,

--- a/routeros/datasource_ip_firewall.go
+++ b/routeros/datasource_ip_firewall.go
@@ -19,6 +19,10 @@ func DatasourceIPFirewall() *schema.Resource {
 - rules (aka filter)
 `,
 		Schema: map[string]*schema.Schema{
+			MetaSkipFields: PropSkipFields(
+				"ingress_priority", "packets", "random",
+			),
+
 			"address_list": getIPFirewallAddrListSchema(),
 			"mangle":       getIPFirewallMangleSchema(),
 			"nat":          getIPFirewallNatSchema(),

--- a/routeros/datasource_ip_firewall_filter.go
+++ b/routeros/datasource_ip_firewall_filter.go
@@ -23,7 +23,7 @@ func getIPFirewallFilterSchema() *schema.Schema {
 					Computed: true,
 				},
 				"bytes": {
-					Type:     schema.TypeFloat,
+					Type:     schema.TypeInt,
 					Computed: true,
 				},
 				"chain": {

--- a/routeros/datasource_ip_firewall_mangle.go
+++ b/routeros/datasource_ip_firewall_mangle.go
@@ -29,7 +29,7 @@ func getIPFirewallMangleSchema() *schema.Schema {
 					Computed: true,
 				},
 				"bytes": {
-					Type:     schema.TypeFloat,
+					Type:     schema.TypeInt,
 					Computed: true,
 				},
 				"chain": {

--- a/routeros/datasource_ip_firewall_nat.go
+++ b/routeros/datasource_ip_firewall_nat.go
@@ -29,7 +29,7 @@ func getIPFirewallNatSchema() *schema.Schema {
 					Computed: true,
 				},
 				"bytes": {
-					Type:     schema.TypeFloat,
+					Type:     schema.TypeInt,
 					Computed: true,
 				},
 				"chain": {

--- a/routeros/datasource_ipv6_firewall_filter.go
+++ b/routeros/datasource_ipv6_firewall_filter.go
@@ -19,7 +19,7 @@ func getIPv6FirewallFilterSchema() *schema.Schema {
 					Computed: true,
 				},
 				"bytes": {
-					Type:     schema.TypeFloat,
+					Type:     schema.TypeInt,
 					Computed: true,
 				},
 				"chain": {

--- a/routeros/datasource_system_resource.go
+++ b/routeros/datasource_system_resource.go
@@ -43,11 +43,11 @@ func DatasourceSystemResource() *schema.Resource {
 			Computed: true,
 		},
 		"total_hdd_space": { // Sample = total-hdd-space: "93564928"
-			Type:     schema.TypeFloat,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
 		"total_memory": { // Sample = total-memory: "469762048"
-			Type:     schema.TypeFloat,
+			Type:     schema.TypeInt,
 			Computed: true,
 		},
 		"version": { // Sample = version: "7.10 (stable)"

--- a/routeros/datasource_system_resource.go
+++ b/routeros/datasource_system_resource.go
@@ -10,6 +10,10 @@ func DatasourceSystemResource() *schema.Resource {
 	resSchema := map[string]*schema.Schema{
 		MetaResourcePath: PropResourcePath("/system/resource"),
 		MetaId:           PropId(Id),
+		MetaSkipFields: PropSkipFields(
+			"cpu_frequency", "cpu_load", "free_hdd_space", "free_memory",
+			"uptime", "write_sect_since_reboot", "write_sect_total",
+		),
 		"architecture_name": { // Sample = architecture-name: "x86_64"
 			Type:     schema.TypeString,
 			Computed: true,


### PR DESCRIPTION
I am not 100% sure if I put PropsSkipFields for the firewall in the right place. They are using a helper schema that is referenced in datasource_ip_firewall.go:

```go
Schema: map[string]*schema.Schema{
			MetaSkipFields: PropSkipFields(
				"ingress_priority", "packets", "random",
			),
```
I also fixed the types from the initial PR and reverted them back to Int.
